### PR TITLE
Update versions, fix jobs and use external Nomad IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pem
 *.csr
 *.swp
+.idea

--- a/docs/03-kubernetes-infrastructure.md
+++ b/docs/03-kubernetes-infrastructure.md
@@ -10,11 +10,17 @@ Kubernetes will be used to host the Nomad control plane including the following 
 
 A Kubernetes 1.7.5+ cluster is required to host the Nomad control plane components. Use the `gcloud` command to provision a three node Kubernetes cluster:
 
+Set your GCP zone:
+```
+GCP_ZONE=us-west1-c
+```
+
 ```
 gcloud container clusters create nomad \
-  --cluster-version 1.7.5 \
   --machine-type n1-standard-2 \
-  --num-nodes 3
+  --num-nodes 3 \
+  --release-channel stable \
+  --zone ${GCP_ZONE}
 ```
 
 It can take several minutes to provision the `nomad` Kubernetes cluster. Either wait for the above command to complete or use the `gcloud` command to monitor progress in a separate terminal:
@@ -46,7 +52,8 @@ gcloud container node-pools create vault-pool \
   --cluster nomad \
   --machine-type n1-standard-2 \
   --num-nodes 2 \
-  --node-labels dedicated=vault
+  --node-labels dedicated=vault \
+  --zone ${GCP_ZONE}
 ```
 
 > Estimated time to completion: 2 minutes.
@@ -54,7 +61,7 @@ gcloud container node-pools create vault-pool \
 List the node pools for the `nomad` Kubernetes cluster:
 
 ```
-gcloud container node-pools list --cluster nomad
+gcloud container node-pools list --cluster nomad --zone ${GCP_ZONE}
 ```
 ```
 NAME          MACHINE_TYPE   DISK_SIZE_GB  NODE_VERSION

--- a/docs/06-vault.md
+++ b/docs/06-vault.md
@@ -66,18 +66,24 @@ vault status
 ```
 
 ```
-Error checking seal status: Error making API request.
-
-URL: GET https://XX.XXX.XXX.XX:8200/v1/sys/seal-status
-Code: 400. Errors:
-
-* server is not yet initialized
+Key                Value
+---                -----
+Seal Type          shamir
+Initialized        false
+Sealed             true
+Total Shares       0
+Threshold          0
+Unseal Progress    0/0
+Unseal Nonce       n/a
+Version            1.8.1
+Storage Type       consul
+HA Enabled         true
 ```
 
-The above error indicates the Vault cluster needs to be initialized. Initialize the Vault cluster:
+The above indicates the Vault cluster needs to be initialized. Initialize the Vault cluster:
 
 ```
-vault init
+vault operator init
 ```
 
 ```
@@ -104,7 +110,7 @@ Save the five unseal keys and the initial root token.
 Unseal the Vault instance using three of the unseal keys:
 
 ```
-vault unseal
+vault operator unseal
 ```
 
 ```
@@ -158,7 +164,7 @@ At this point the Vault cluster has been initialized and is ready for use.
 Login to the Vault cluster using the initial root token:
 
 ```
-vault auth
+vault login
 ```
 
 ```
@@ -178,7 +184,7 @@ Nomad has native [Vault integration](https://www.nomadproject.io/docs/vault-inte
 Create the `nomad-server` policy:
 
 ```
-vault policy-write nomad-server nomad-server-policy.hcl
+vault policy write nomad-server nomad-server-policy.hcl
 ```
 
 Create the `nomad-cluster` role:
@@ -190,7 +196,7 @@ vault write /auth/token/roles/nomad-cluster @nomad-cluster-role.json
 Generate a new role based Vault token based on the `nomad-server` policy:
 
 ```
-NOMAD_VAULT_TOKEN=$(vault token-create \
+NOMAD_VAULT_TOKEN=$(vault token create \
   -policy nomad-server \
   -period 72h \
   -orphan \

--- a/docs/07-nomad.md
+++ b/docs/07-nomad.md
@@ -62,7 +62,7 @@ source nomad.env
 List the Nomad cluster server members:
 
 ```
-nomad server-members
+nomad server members
 ```
 
 ```

--- a/jobs/ping.nomad
+++ b/jobs/ping.nomad
@@ -4,8 +4,10 @@ job "ping" {
   type = "service"
 
   group "example" {
+    count = 2
+
     task "ping" {
-      driver = "exec"
+      driver = "raw_exec"
 
       config {
         command = "/bin/ping"

--- a/statefulsets/consul.yaml
+++ b/statefulsets/consul.yaml
@@ -1,14 +1,17 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: consul
 spec:
+  selector:
+    matchLabels:
+      app: consul # has to match .spec.template.metadata.labels
   serviceName: consul
   replicas: 3
   template:
     metadata:
       labels:
-        app: consul
+        app: consul # has to match .spec.selector.matchLabels
     spec:
       affinity:
         podAntiAffinity:
@@ -22,7 +25,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
         - name: consul
-          image: "consul:0.9.3"
+          image: "consul:1.10.1"
           env:
             - name: GOSSIP_ENCRYPTION_KEY
               valueFrom:

--- a/statefulsets/nomad.yaml
+++ b/statefulsets/nomad.yaml
@@ -1,14 +1,17 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: nomad
 spec:
+  selector:
+    matchLabels:
+      app: nomad # has to match .spec.template.metadata.labels
   serviceName: nomad
   replicas: 3
   template:
     metadata:
       labels:
-        app: nomad
+        app: nomad # has to match .spec.selector.matchLabels
     spec:
       affinity:
         podAntiAffinity:
@@ -22,7 +25,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
         - name: nomad
-          image: "gcr.io/hightowerlabs/nomad:0.6.3"
+          image: "multani/nomad:1.1.3"
           env:
             - name: VAULT_TOKEN
               valueFrom:
@@ -59,7 +62,7 @@ spec:
             - name: vault-tls
               mountPath: /etc/vault/tls
         - name: consul
-          image: "consul:0.9.3"
+          image: "consul:1.10.1"
           env:
             - name: GOSSIP_ENCRYPTION_KEY
               valueFrom:

--- a/statefulsets/vault.yaml
+++ b/statefulsets/vault.yaml
@@ -1,14 +1,17 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: vault
 spec:
+  selector:
+    matchLabels:
+      app: vault # has to match .spec.template.metadata.labels
   serviceName: vault
   replicas: 1
   template:
     metadata:
       labels:
-        app: vault
+        app: vault # has to match .spec.selector.matchLabels
     spec:
       affinity:
         podAntiAffinity:
@@ -29,7 +32,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: vault
-          image: "vault:0.8.2"
+          image: "vault:1.8.1"
           args:
             - "server"
             - "-config=/etc/vault/config/vault.hcl"


### PR DESCRIPTION
- Updates statefulsets to latest K8S specification.
- Updates Nomad, Vault and Consul versions to latest stable.
- Updates documentation to ensure gcloud, k8s and nomad interactions are up to date.
- Fixes the nomad ping job as the exec driver doesn't work on Ubuntu 20.04.
- Refactors the Nomad startup script to only install Nomad, not Consul.
- Refactors the Nomad startup script to use the server_join stanza configured with the external IP address of the LoadBalancer created in K8S for Nomad